### PR TITLE
Update to 1.20

### DIFF
--- a/data/minecraft/loot_tables/chests/shipwreck_map.json
+++ b/data/minecraft/loot_tables/chests/shipwreck_map.json
@@ -76,6 +76,28 @@
         }
       ],
       "rolls": 3.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:empty",
+          "weight": 5
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            }
+          ],
+          "name": "minecraft:coast_armor_trim_smithing_template"
+        }
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:chests/shipwreck_map"
 }

--- a/data/minecraft/loot_tables/chests/underwater_ruin_big.json
+++ b/data/minecraft/loot_tables/chests/underwater_ruin_big.json
@@ -101,5 +101,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:chests/underwater_ruin_big"
 }

--- a/data/minecraft/loot_tables/chests/underwater_ruin_small.json
+++ b/data/minecraft/loot_tables/chests/underwater_ruin_small.json
@@ -81,5 +81,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:chests/underwater_ruin_small"
 }

--- a/data/minecraft/loot_tables/gameplay/cat_morning_gift.json
+++ b/data/minecraft/loot_tables/gameplay/cat_morning_gift.json
@@ -47,5 +47,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:gameplay/cat_morning_gift"
 }

--- a/data/minecraft/loot_tables/gameplay/fishing.json
+++ b/data/minecraft/loot_tables/gameplay/fishing.json
@@ -37,5 +37,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:gameplay/fishing"
 }

--- a/data/minecraft/loot_tables/gameplay/fishing/fish.json
+++ b/data/minecraft/loot_tables/gameplay/fishing/fish.json
@@ -27,5 +27,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:gameplay/fishing/fish"
 }

--- a/data/minecraft/loot_tables/gameplay/fishing/junk.json
+++ b/data/minecraft/loot_tables/gameplay/fishing/junk.json
@@ -199,5 +199,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:gameplay/fishing/junk"
 }

--- a/data/minecraft/loot_tables/gameplay/fishing/treasure.json
+++ b/data/minecraft/loot_tables/gameplay/fishing/treasure.json
@@ -70,5 +70,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:gameplay/fishing/treasure"
 }

--- a/data/minecraft/worldgen/biome/badlands.json
+++ b/data/minecraft/worldgen/biome/badlands.json
@@ -11,12 +11,18 @@
       "sound": "minecraft:ambient.cave",
       "tick_delay": 6000
     },
+    "music": {
+      "max_delay": 24000,
+      "min_delay": 12000,
+      "replace_current_music": false,
+      "sound": "minecraft:music.overworld.badlands"
+    },
     "sky_color": 7254527,
     "water_color": 4159204,
     "water_fog_color": 329011
   },
   "features": [],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/bamboo_jungle.json
+++ b/data/minecraft/worldgen/biome/bamboo_jungle.json
@@ -13,7 +13,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.bamboo_jungle"
     },
     "sky_color": 7842047,
     "water_color": 4159204,
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/basalt_deltas.json
+++ b/data/minecraft/worldgen/biome/basalt_deltas.json
@@ -62,7 +62,7 @@
       "minecraft:ore_debris_small"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/beach.json
+++ b/data/minecraft/worldgen/biome/beach.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/birch_forest.json
+++ b/data/minecraft/worldgen/biome/birch_forest.json
@@ -13,7 +13,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.forest"
     },
     "sky_color": 8037887,
     "water_color": 4159204,
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/cherry_grove.json
+++ b/data/minecraft/worldgen/biome/cherry_grove.json
@@ -1,0 +1,132 @@
+{
+  "carvers": {},
+  "downfall": 0.8,
+  "effects": {
+    "fog_color": 12638463,
+    "foliage_color": 11983713,
+    "grass_color": 11983713,
+    "mood_sound": {
+      "block_search_extent": 8,
+      "offset": 2.0,
+      "sound": "minecraft:ambient.cave",
+      "tick_delay": 6000
+    },
+    "music": {
+      "max_delay": 24000,
+      "min_delay": 12000,
+      "replace_current_music": false,
+      "sound": "minecraft:music.overworld.cherry_grove"
+    },
+    "sky_color": 8103167,
+    "water_color": 6141935,
+    "water_fog_color": 6141935
+  },
+  "features": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "has_precipitation": true,
+  "spawn_costs": {},
+  "spawners": {
+    "ambient": [
+      {
+        "type": "minecraft:bat",
+        "maxCount": 8,
+        "minCount": 8,
+        "weight": 10
+      }
+    ],
+    "axolotls": [],
+    "creature": [
+      {
+        "type": "minecraft:pig",
+        "maxCount": 2,
+        "minCount": 1,
+        "weight": 1
+      },
+      {
+        "type": "minecraft:rabbit",
+        "maxCount": 6,
+        "minCount": 2,
+        "weight": 2
+      },
+      {
+        "type": "minecraft:sheep",
+        "maxCount": 4,
+        "minCount": 2,
+        "weight": 2
+      }
+    ],
+    "misc": [],
+    "monster": [
+      {
+        "type": "minecraft:spider",
+        "maxCount": 4,
+        "minCount": 4,
+        "weight": 100
+      },
+      {
+        "type": "minecraft:zombie",
+        "maxCount": 4,
+        "minCount": 4,
+        "weight": 95
+      },
+      {
+        "type": "minecraft:zombie_villager",
+        "maxCount": 1,
+        "minCount": 1,
+        "weight": 5
+      },
+      {
+        "type": "minecraft:skeleton",
+        "maxCount": 4,
+        "minCount": 4,
+        "weight": 100
+      },
+      {
+        "type": "minecraft:creeper",
+        "maxCount": 4,
+        "minCount": 4,
+        "weight": 100
+      },
+      {
+        "type": "minecraft:slime",
+        "maxCount": 4,
+        "minCount": 4,
+        "weight": 100
+      },
+      {
+        "type": "minecraft:enderman",
+        "maxCount": 4,
+        "minCount": 1,
+        "weight": 10
+      },
+      {
+        "type": "minecraft:witch",
+        "maxCount": 1,
+        "minCount": 1,
+        "weight": 5
+      }
+    ],
+    "underground_water_creature": [
+      {
+        "type": "minecraft:glow_squid",
+        "maxCount": 6,
+        "minCount": 4,
+        "weight": 10
+      }
+    ],
+    "water_ambient": [],
+    "water_creature": []
+  },
+  "temperature": 0.5
+}

--- a/data/minecraft/worldgen/biome/cold_ocean.json
+++ b/data/minecraft/worldgen/biome/cold_ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/crimson_forest.json
+++ b/data/minecraft/worldgen/biome/crimson_forest.json
@@ -64,7 +64,7 @@
       "minecraft:crimson_forest_vegetation"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/dark_forest.json
+++ b/data/minecraft/worldgen/biome/dark_forest.json
@@ -14,7 +14,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.forest"
     },
     "sky_color": 7972607,
     "water_color": 4159204,
@@ -33,7 +33,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/deep_cold_ocean.json
+++ b/data/minecraft/worldgen/biome/deep_cold_ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/deep_dark.json
+++ b/data/minecraft/worldgen/biome/deep_dark.json
@@ -35,7 +35,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/deep_frozen_ocean.json
+++ b/data/minecraft/worldgen/biome/deep_frozen_ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/deep_lukewarm_ocean.json
+++ b/data/minecraft/worldgen/biome/deep_lukewarm_ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/deep_ocean.json
+++ b/data/minecraft/worldgen/biome/deep_ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/desert.json
+++ b/data/minecraft/worldgen/biome/desert.json
@@ -9,6 +9,12 @@
       "sound": "minecraft:ambient.cave",
       "tick_delay": 6000
     },
+    "music": {
+      "max_delay": 24000,
+      "min_delay": 12000,
+      "replace_current_music": false,
+      "sound": "minecraft:music.overworld.desert"
+    },
     "sky_color": 7254527,
     "water_color": 4159204,
     "water_fog_color": 329011
@@ -19,7 +25,7 @@
       "minecraft:patch_dead_bush"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/dripstone_caves.json
+++ b/data/minecraft/worldgen/biome/dripstone_caves.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/end_barrens.json
+++ b/data/minecraft/worldgen/biome/end_barrens.json
@@ -18,7 +18,7 @@
       "amethyst_geode"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/end_highlands.json
+++ b/data/minecraft/worldgen/biome/end_highlands.json
@@ -30,7 +30,7 @@
       "minecraft:chorus_plant"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/end_midlands.json
+++ b/data/minecraft/worldgen/biome/end_midlands.json
@@ -18,7 +18,7 @@
       "amethyst_geode"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/eroded_badlands.json
+++ b/data/minecraft/worldgen/biome/eroded_badlands.json
@@ -18,6 +18,12 @@
       "sound": "minecraft:ambient.cave",
       "tick_delay": 6000
     },
+    "music": {
+      "max_delay": 24000,
+      "min_delay": 12000,
+      "replace_current_music": false,
+      "sound": "minecraft:music.overworld.badlands"
+    },
     "sky_color": 7254527,
     "water_color": 4159204,
     "water_fog_color": 329011
@@ -35,7 +41,7 @@
     [],
     []
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/flower_forest.json
+++ b/data/minecraft/worldgen/biome/flower_forest.json
@@ -38,7 +38,7 @@
       "minecraft:freeze_top_layer"
     ]
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/flower_forest.json
+++ b/data/minecraft/worldgen/biome/flower_forest.json
@@ -13,7 +13,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.flower_forest"
     },
     "sky_color": 7972607,
     "water_color": 4159204,

--- a/data/minecraft/worldgen/biome/forest.json
+++ b/data/minecraft/worldgen/biome/forest.json
@@ -13,7 +13,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.forest"
     },
     "sky_color": 7972607,
     "water_color": 4159204,
@@ -33,6 +33,8 @@
     []
   ],
   "precipitation": "rain",
+  "spawn_costs": {},
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/frozen_ocean.json
+++ b/data/minecraft/worldgen/biome/frozen_ocean.json
@@ -16,26 +16,18 @@
   },
   "features": [
     [],
-    [
-    ],
-    [
-    ],
-    [
-    ],
-    [
-    ],
     [],
-    [
-    ],
     [],
-    [
-    ],
-    [
-    ],
-    [
-    ]
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/frozen_peaks.json
+++ b/data/minecraft/worldgen/biome/frozen_peaks.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/frozen_river.json
+++ b/data/minecraft/worldgen/biome/frozen_river.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/grove.json
+++ b/data/minecraft/worldgen/biome/grove.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/ice_spikes.json
+++ b/data/minecraft/worldgen/biome/ice_spikes.json
@@ -27,7 +27,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/jagged_peaks.json
+++ b/data/minecraft/worldgen/biome/jagged_peaks.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/jungle.json
+++ b/data/minecraft/worldgen/biome/jungle.json
@@ -13,7 +13,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.jungle"
     },
     "sky_color": 7842047,
     "water_color": 4159204,
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/lukewarm_ocean.json
+++ b/data/minecraft/worldgen/biome/lukewarm_ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/lush_caves.json
+++ b/data/minecraft/worldgen/biome/lush_caves.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/mangrove_swamp.json
+++ b/data/minecraft/worldgen/biome/mangrove_swamp.json
@@ -34,7 +34,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/meadow.json
+++ b/data/minecraft/worldgen/biome/meadow.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/mushroom_fields.json
+++ b/data/minecraft/worldgen/biome/mushroom_fields.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/nether_wastes.json
+++ b/data/minecraft/worldgen/biome/nether_wastes.json
@@ -58,7 +58,7 @@
       "minecraft:red_mushroom_normal"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/ocean.json
+++ b/data/minecraft/worldgen/biome/ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/old_growth_birch_forest.json
+++ b/data/minecraft/worldgen/biome/old_growth_birch_forest.json
@@ -13,7 +13,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.forest"
     },
     "sky_color": 8037887,
     "water_color": 4159204,
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/old_growth_pine_taiga.json
+++ b/data/minecraft/worldgen/biome/old_growth_pine_taiga.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/old_growth_spruce_taiga.json
+++ b/data/minecraft/worldgen/biome/old_growth_spruce_taiga.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/plains.json
+++ b/data/minecraft/worldgen/biome/plains.json
@@ -28,7 +28,7 @@
     ],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/river.json
+++ b/data/minecraft/worldgen/biome/river.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/savanna.json
+++ b/data/minecraft/worldgen/biome/savanna.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/savanna_plateau.json
+++ b/data/minecraft/worldgen/biome/savanna_plateau.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/small_end_islands.json
+++ b/data/minecraft/worldgen/biome/small_end_islands.json
@@ -18,7 +18,7 @@
       "minecraft:end_island_decorated"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/snowy_beach.json
+++ b/data/minecraft/worldgen/biome/snowy_beach.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/snowy_plains.json
+++ b/data/minecraft/worldgen/biome/snowy_plains.json
@@ -27,7 +27,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/snowy_slopes.json
+++ b/data/minecraft/worldgen/biome/snowy_slopes.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/snowy_taiga.json
+++ b/data/minecraft/worldgen/biome/snowy_taiga.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "snow",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/soul_sand_valley.json
+++ b/data/minecraft/worldgen/biome/soul_sand_valley.json
@@ -64,7 +64,7 @@
       "minecraft:spring_lava"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {
     "minecraft:enderman": {
       "charge": 0.7,

--- a/data/minecraft/worldgen/biome/sparse_jungle.json
+++ b/data/minecraft/worldgen/biome/sparse_jungle.json
@@ -13,7 +13,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.sparse_jungle"
     },
     "sky_color": 7842047,
     "water_color": 4159204,
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/stony_peaks.json
+++ b/data/minecraft/worldgen/biome/stony_peaks.json
@@ -32,7 +32,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/stony_shore.json
+++ b/data/minecraft/worldgen/biome/stony_shore.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/sunflower_plains.json
+++ b/data/minecraft/worldgen/biome/sunflower_plains.json
@@ -28,7 +28,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/swamp.json
+++ b/data/minecraft/worldgen/biome/swamp.json
@@ -39,7 +39,7 @@
     ],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/taiga.json
+++ b/data/minecraft/worldgen/biome/taiga.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/the_end.json
+++ b/data/minecraft/worldgen/biome/the_end.json
@@ -22,7 +22,7 @@
       "minecraft:end_spike"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/the_void.json
+++ b/data/minecraft/worldgen/biome/the_void.json
@@ -28,7 +28,7 @@
       "minecraft:void_start_platform"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [],

--- a/data/minecraft/worldgen/biome/warm_ocean.json
+++ b/data/minecraft/worldgen/biome/warm_ocean.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/warped_forest.json
+++ b/data/minecraft/worldgen/biome/warped_forest.json
@@ -66,7 +66,7 @@
       "minecraft:twisting_vines"
     ]
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {
     "minecraft:enderman": {
       "charge": 1.0,

--- a/data/minecraft/worldgen/biome/windswept_forest.json
+++ b/data/minecraft/worldgen/biome/windswept_forest.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/windswept_gravelly_hills.json
+++ b/data/minecraft/worldgen/biome/windswept_gravelly_hills.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/windswept_hills.json
+++ b/data/minecraft/worldgen/biome/windswept_hills.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "rain",
+  "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/windswept_savanna.json
+++ b/data/minecraft/worldgen/biome/windswept_savanna.json
@@ -26,7 +26,7 @@
     [],
     []
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/data/minecraft/worldgen/biome/wooded_badlands.json
+++ b/data/minecraft/worldgen/biome/wooded_badlands.json
@@ -11,6 +11,12 @@
       "sound": "minecraft:ambient.cave",
       "tick_delay": 6000
     },
+    "music": {
+      "max_delay": 24000,
+      "min_delay": 12000,
+      "replace_current_music": false,
+      "sound": "minecraft:music.overworld.badlands"
+    },
     "sky_color": 7254527,
     "water_color": 4159204,
     "water_fog_color": 329011
@@ -28,7 +34,7 @@
     [],
     []
   ],
-  "precipitation": "none",
+  "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
     "ambient": [

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 10,
+    "pack_format": 15,
     "description": "slime"
   }
 }


### PR DESCRIPTION
Changelog:
```
Biome changes:
- "precipitation" changed to "has_precipitation"
- All forest biomes have their own music IDs instead of all using "jungle_and_forest".
- Added music tag to Desert, Badlands and Wooded Badlands biome
- Added Cherry Grove biome
- Fixed Frozen Ocean features tag formatting

Loot Table changes:
- Added "coast_armor_trim_smithing_template" to Shipwreck map chest loot table
- Added "random_sequence" tag to all custom loot tables

General changes:
- Data pack format changed to 15
```